### PR TITLE
Fix mangrove crash

### DIFF
--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -383,9 +383,15 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             if (topType == OutputNodeType::InArray) return;
         }
 
-        if (!_nextName && _nodeTypeStack.empty() && isNewNode) {
-            // This is a document at the root node with no name.
-            // Do nothing since no name is expected for non root-element documents in root.
+        if ((!_nextName && _nodeTypeStack.empty() && isNewNode) ||
+                (_nextName && isNewNode)) {
+            // This is a document:
+            //  * at the root node with no name.
+            //    Do nothing since no name is expected for non root-element documents in root.
+            //  * embedded document
+            //    Do nothing since no value expected for this key.
+            //    Example: 
+            //      embedded document "user.profile" but key with value is "user.profile.email"
             return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,

--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -394,7 +394,7 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
         } else {
             // Set the key of this element to the name stored by the archiver.
             if (!_dotNotationMode || _embeddedNameStack.empty() || _arrayNestingLevel > 0) {
-                if (!isNewNode)
+                if (!isNewNode || !_dotNotationMode)
                     _bsonBuilder.key_view(_nextName);
             } else {
                 // If we are in dot notation mode and we're not nested in array, build the name of

--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -383,15 +383,9 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             if (topType == OutputNodeType::InArray) return;
         }
 
-        if ((!_nextName && _nodeTypeStack.empty() && isNewNode) ||
-                (_nextName && isNewNode)) {
-            // This is a document:
-            //  * at the root node with no name.
-            //    Do nothing since no name is expected for non root-element documents in root.
-            //  * embedded document
-            //    Do nothing since no value expected for this key.
-            //    Example: 
-            //      embedded document "user.profile" but key with value is "user.profile.email"
+        if (!_nextName && _nodeTypeStack.empty() && isNewNode) {
+            // This is a document at the root node with no name.
+            // Do nothing since no name is expected for non root-element documents in root.
             return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,

--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -387,6 +387,13 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             // This is a document at the root node with no name.
             // Do nothing since no name is expected for non root-element documents in root.
             return;
+        } else if (_nextName && isNewNode) {
+            // Do nothing since no value expected for this key.
+            // Save key name in _embeddedNameStack for next rounds
+            // Example:
+            //  embedded document "user.profile" but key with value is "user.profile.email"
+            _embeddedNameStack.push_back(_nextName);
+            return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,
             // or this in an element in root.

--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -387,13 +387,6 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             // This is a document at the root node with no name.
             // Do nothing since no name is expected for non root-element documents in root.
             return;
-        } else if (_nextName && isNewNode) {
-            // Do nothing since no value expected for this key.
-            // Save key name in _embeddedNameStack for next rounds
-            // Example:
-            //  embedded document "user.profile" but key with value is "user.profile.email"
-            _embeddedNameStack.push_back(_nextName);
-            return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,
             // or this in an element in root.

--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -394,7 +394,8 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
         } else {
             // Set the key of this element to the name stored by the archiver.
             if (!_dotNotationMode || _embeddedNameStack.empty() || _arrayNestingLevel > 0) {
-                _bsonBuilder.key_view(_nextName);
+                if (!isNewNode)
+                    _bsonBuilder.key_view(_nextName);
             } else {
                 // If we are in dot notation mode and we're not nested in array, build the name of
                 // this key.

--- a/src/boson/bson_streambuf.cpp
+++ b/src/boson/bson_streambuf.cpp
@@ -67,7 +67,7 @@ int bson_output_streambuf::insert(int ch) {
     }
 
     // This creates the document from the given bytes, and calls the user-provided callback.
-    if (_bytes_read == _len) {
+    if (_bytes_read == _len && _len > 4) {
         _cb({std::move(_data), _len});
         _bytes_read = 0;
         _len = 0;


### PR DESCRIPTION
Crash observed when document length is 257 byte, for example.
It represents as '0x01 01 00 00'.
In this case '_bytes_read == _len' equal to 1 and callback is called
with partial buffer (only 1 byte actually). This cause later crash in
'to_dotted_notation_document'

Signed-off-by: Abylay Ospan <aospan@netup.ru>