### PR TITLE
Fix embedded doc exception with new mongo-cxx

### DIFF
--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -383,9 +383,15 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             if (topType == OutputNodeType::InArray) return;
         }
 
-        if (!_nextName && _nodeTypeStack.empty() && isNewNode) {
-            // This is a document at the root node with no name.
-            // Do nothing since no name is expected for non root-element documents in root.
+        if ((!_nextName && _nodeTypeStack.empty() && isNewNode) ||
+                (_nextName && isNewNode)) {
+            // This is a document:
+            //  * at the root node with no name.
+            //    Do nothing since no name is expected for non root-element documents in root.
+            //  * embedded document
+            //    Do nothing since no value expected for this key.
+            //    Example: 
+            //      embedded document "user.profile" but key with value is "user.profile.email"
             return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,


### PR DESCRIPTION
With mongo-cxx-3.2+ we have exception:

terminate called after throwing an instance of
'bsoncxx::v_noabi::exception'
  what():  can't convert builder to a valid view: unmatched key

while using embedded documents. For example:
    {
        "name" : "Jenny",
        "contact_info" :
            {
                "type" : "home"
            }
    }

we have called twice:
 1. for "contact_info" key
 2. for "contact_info.type" key

in mongo-cxx-3.2+ we can't call key_view/key_owned twice. Otherwise we
receive exception as described above.

Signed-off-by: Abylay Ospan <aospan@netup.ru>