### PR TITLE
Fix embedded doc exception with new mongo-cxx

### DIFF
--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -387,6 +387,13 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
             // This is a document at the root node with no name.
             // Do nothing since no name is expected for non root-element documents in root.
             return;
+        } else if (_nextName && isNewNode) {
+            // Do nothing since no value expected for this key.
+            // Save key name in _embeddedNameStack for next rounds
+            // Example:
+            //  embedded document "user.profile" but key with value is "user.profile.email"
+            _embeddedNameStack.push_back(_nextName);
+            return;
         } else if (!_nextName) {
             // Enforce the existence of a name-value pair if this is not a node in root,
             // or this in an element in root.


### PR DESCRIPTION
With modern mongo-cxx (tested on 3.3.1) we have exception while using
embedded documents:

terminate called after throwing an instance of
'bsoncxx::v_noabi::exception'
what(): can't convert builder to a valid view: unmatched key

For example:
{
    "name" : "Jenny",
    "contact_info" :
    {
        "type" : "home"
    }
}

we have called twice:
    1. for "contact_info" key
    2. for "contact_info.type" key

we can't call key_view/key_owned twice.
Otherwise we receive exception as described above.

Signed-off-by: Abylay Ospan <aospan@netup.ru>