### PR TITLE
Fix embedded doc exception with new mongo-cxx

### DIFF
--- a/src/boson/bson_archiver.hpp
+++ b/src/boson/bson_archiver.hpp
@@ -394,7 +394,8 @@ class BSONOutputArchive : public cereal::OutputArchive<BSONOutputArchive> {
         } else {
             // Set the key of this element to the name stored by the archiver.
             if (!_dotNotationMode || _embeddedNameStack.empty() || _arrayNestingLevel > 0) {
-                _bsonBuilder.key_view(_nextName);
+                if (!isNewNode)
+                    _bsonBuilder.key_view(_nextName);
             } else {
                 // If we are in dot notation mode and we're not nested in array, build the name of
                 // this key.


### PR DESCRIPTION
With modern mongo-cxx (tested on 3.3.1) we have exception while using
embedded documents:

    terminate called after throwing an instance of
    'bsoncxx::v_noabi::exception'
    what(): can't convert builder to a valid view: unmatched key

For example:
{
    "name" : "Jenny",
    "contact_info" :
    {
        "type" : "home"
    }
}

we have called twice:
 1. for "contact_info" key
 2. for "contact_info.type" key

we can't call key_view/key_owned twice.
Otherwise we receive exception as described above.

Signed-off-by: Abylay Ospan <aospan@netup.ru>