### PR TITLE
Add MANGROVE_ROOT_DIR & MANGROVE_ROOT_BINARY_DIR variable in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,14 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(GenerateExportHeader)
 include(InstallRequiredSystemLibraries)
 
+set(MANGROVE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+file(RELATIVE_PATH MANGROVE_ROOT_BINARY_DIR ${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set(MANGROVE_ROOT_BINARY_DIR ${CMAKE_BINARY_DIR}/${MANGROVE_ROOT_BINARY_DIR})
+
 # If the user did not customize the install prefix,
 # set it to live under build so we don't inadverently pollute /usr/local
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set (CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
+    set (CMAKE_INSTALL_PREFIX "${MANGROVE_ROOT_BINARY_DIR}/install" CACHE PATH "default install path" FORCE)
 endif()
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -71,12 +75,12 @@ endif()
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_custom_target(format
-    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py format
+    python ${MANGROVE_ROOT_DIR}/etc/clang_format.py format
     VERBATIM
 )
 
 add_custom_target(format-lint
-    python ${CMAKE_SOURCE_DIR}/etc/clang_format.py lint
+    python ${MANGROVE_ROOT_DIR}/etc/clang_format.py lint
     VERBATIM
 )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -34,12 +34,12 @@ add_custom_target(run-examples DEPENDS examples)
 
 # Run all boson examples on `make run-examples`.
 foreach(EXAMPLE ${BOSON_EXAMPLE_EXECUTABLES})
-    get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/boson/${EXAMPLE}" ABSOLUTE)
+    get_filename_component(EXAMPLE_EXECUTABLE "${MANGROVE_ROOT_BINARY_DIR}/examples/boson/${EXAMPLE}" ABSOLUTE)
     add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})
 endforeach(EXAMPLE)
 
 # Run all mangrove examples on `make run-examples`.
 foreach(EXAMPLE ${MANGROVE_EXAMPLE_EXECUTABLES})
-    get_filename_component(EXAMPLE_EXECUTABLE "${CMAKE_BINARY_DIR}/examples/mangrove/${EXAMPLE}" ABSOLUTE)
+    get_filename_component(EXAMPLE_EXECUTABLE "${MANGROVE_ROOT_BINARY_DIR}/examples/mangrove/${EXAMPLE}" ABSOLUTE)
     add_custom_command(TARGET run-examples POST_BUILD COMMAND ${EXAMPLE_EXECUTABLE})
 endforeach(EXAMPLE)

--- a/src/boson/test/CMakeLists.txt
+++ b/src/boson/test/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
+    ${MANGROVE_ROOT_DIR}/src/third_party/catch/include
 )
 
 add_executable(test_boson

--- a/src/mangrove/CMakeLists.txt
+++ b/src/mangrove/CMakeLists.txt
@@ -46,7 +46,7 @@ add_subdirectory(config)
 
 # auto-generate MANGROVE_CHILD macros for accessing nested fields in the query builder.
 message(STATUS "Generating MANGROVE_CHILD preprocessor macros...")
-execute_process(COMMAND ${CMAKE_SOURCE_DIR}/buildscripts/generate_macros.py ${CMAKE_SOURCE_DIR}/src/mangrove/mangrove_child_autogen.hpp)
+execute_process(COMMAND ${MANGROVE_ROOT_DIR}/buildscripts/generate_macros.py ${MANGROVE_ROOT_DIR}/src/mangrove/mangrove_child_autogen.hpp)
 
 set(mangrove_sources
    "model.cpp"
@@ -58,9 +58,9 @@ include_directories(
     ${LIBMONGOCXX_INCLUDE_DIRS}
     ${LIBBSON_INCLUDE_DIRS}
     ${LIBMONGOC_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/src
-    ${CMAKE_BINARY_DIR}/src
-    ${CMAKE_SOURCE_DIR}/src/third_party/cereal/include
+    ${MANGROVE_ROOT_DIR}/src
+    ${MANGROVE_ROOT_BINARY_DIR}/src
+    ${MANGROVE_ROOT_DIR}/src/third_party/cereal/include
 )
 
 link_directories(

--- a/src/mangrove/test/CMakeLists.txt
+++ b/src/mangrove/test/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 include_directories(
-    ${CMAKE_SOURCE_DIR}/src/third_party/catch/include
+    ${MANGROVE_ROOT_DIR}/src/third_party/catch/include
 )
 
 add_executable(test_mangrove


### PR DESCRIPTION
I came accross a minor issue when trying to add `mangrove` as a cmake subdirectory.

This pull request should fix this without any impact on the initial behavior

All `CMAKE_SOURCE_DIR` reference were replaced by `MANGROVE_ROOT_DIR`
All `CMAKE_BINARY_DIR` reference were replaced by `MANGROVE_ROOT_BINARY_DIR `